### PR TITLE
Move the source loading to a separate function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
- - "6"
  - "8"
  - "10"
+ - "12"
  - "node"
 script:
   - npm run build

--- a/lib/PromiseProxyIterator.ts
+++ b/lib/PromiseProxyIterator.ts
@@ -15,10 +15,16 @@ export class PromiseProxyIterator<T> extends TransformIterator<T, T> {
     this.sourceGetter = sourceGetter;
   }
 
+  public async loadSource(): Promise<AsyncIterator<T>> {
+    if (!this.source) {
+      this.source = await this.sourceGetter();
+    }
+    return this.source;
+  }
+
   public _read(count: number, done: () => void): void {
     if (!this.source) {
-      this.sourceGetter().then((source: AsyncIterator<T>) => {
-        this.source = source;
+      this.loadSource().then((source: AsyncIterator<T>) => {
         super._read(count, done);
       }).catch((error) => this.emit('error', error));
     } else {

--- a/test/PromiseProxyIterator-test.ts
+++ b/test/PromiseProxyIterator-test.ts
@@ -15,18 +15,30 @@ describe('PromiseProxyIterator', () => {
 
   describe('A PromiseProxyIterator instance', () => {
     let iterator: PromiseProxyIterator<number>;
-    let called: boolean;
+    let called: number;
 
     beforeEach(() => {
-      called = false;
+      called = 0;
       iterator = new PromiseProxyIterator(() => new Promise((resolve, reject) => {
-        called = true;
+        ++called;
         resolve(AsyncIterator.range(0, 10));
       }));
     });
 
     it('should not create the source before the proxy is called', () => {
       return expect(called).toBeFalsy();
+    });
+
+    it('should create the source when the loadSource function is called', async () => {
+      await iterator.loadSource();
+      expect(called).toBeTruthy();
+    });
+
+    it('should return the source when calling loadSource for the second time', async () => {
+      const source1 = await iterator.loadSource();
+      const source2 = await iterator.loadSource();
+      expect(called).toBe(1);
+      expect(source1).toBe(source2);
     });
 
     it('should create the source when the proxy is called', () => {


### PR DESCRIPTION
This is required for the change suggested in comunica/comunica#553 .

Also updated the travis node versions since tests were failing on node 6.